### PR TITLE
Исправление багов в версии 1.4.6

### DIFF
--- a/assets/tvs/selector/lib/controller.class.php
+++ b/assets/tvs/selector/lib/controller.class.php
@@ -15,12 +15,12 @@ class SelectorController
         'JSONformat'          => 'old',
         'display'             => 10,
         'offset'              => 0,
-        'sortBy'              => 'id',
+        'sortBy'              => 'c.id',
         'sortDir'             => 'desc',
         'parents'             => 0,
         'showParent'          => 1,
         'depth'               => 10,
-        'searchContentFields' => 'id,pagetitle,longtitle',
+        'searchContentFields' => 'c.id,c.pagetitle,c.longtitle',
         'searchTVFields'      => '',
         'idField'             => 'id',
         'textField'           => 'pagetitle',
@@ -109,9 +109,11 @@ class SelectorController
                 $filters[] = "content:{$field}:{$mode}:{$search}";
             }
 
-            $searchTVFields = explode(',', $this->dlParams['searchTVFields']);
-            foreach ($searchTVFields as $tv) {
-                $filters[] = "tv:{$tv}:{$mode}:{$search}";
+            if (!empty($this->dlParams['searchTVFields'])) {
+                $searchTVFields = explode(',', $this->dlParams['searchTVFields']);
+                foreach ($searchTVFields as $tv) {
+                    $filters[] = "tv:{$tv}:{$mode}:{$search}";
+                }
             }
             $filters = implode(';', $filters);
             if (!empty($filters)) {


### PR DESCRIPTION
В версии 1.4.6 
1.из за пустого параметра
searchTVFields, параметр filters получали вида
OR(content:c.id:like:М;content:c.pagetitle:like:М;content:c.longtitle:like:М;tv::like:М)
из за такого херился sql запрос
http://joxi.ru/bmo8PekTx8djP2 и ничего не искалось.
2. Если все таки передали что-то в searchTVFields также ломалось из за конфлитка одинаковых id
http://joxi.ru/LmGd6K8HeXDnG2